### PR TITLE
fix add yarn package command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dagger helps users to develop faster and better Ethereum DApps. For more informa
 ---
 ```sh
 # Using Yarn
-yarn add eth-dagger
+yarn add @maticnetwork/eth-dagger
 
 # Using NPM
 npm install @maticnetwork/eth-dagger --save


### PR DESCRIPTION
`yarn add eth-dagger` was installing an earlier version of the Dagger.